### PR TITLE
make this package usable without phpcs: @IgnoreAnnotation("phpcs:disable")

### DIFF
--- a/Classes/Debug.php
+++ b/Classes/Debug.php
@@ -11,6 +11,7 @@ use Neos\Fusion\FusionObjects\AbstractFusionObject;
 use ReflectionObject;
 
 /**
+ * @IgnoreAnnotation("phpcs:disable")
  * @Flow\Scope("singleton")
  */
 final class Debug implements ProtectedContextAwareInterface


### PR DESCRIPTION
this will suppress the error:

```
[Semantical Error] The annotation "@phpcs:disable" in method PackageFactory\Fusion\Debug\Debug::var_dump() was never imported.
...
Doctrine\Common\Annotations\AnnotationException
```

this will ignore phpcs:disable annotations
```
@IgnoreAnnotation("phpcs:disable")
```

i think this might be just an issue, when the dev dependency "squizlabs/php_codesniffer" is not installed.

see https://stackoverflow.com/questions/41496487/how-to-tell-symfony-3-to-ignore-certain-annotations

resolves: #1